### PR TITLE
Do not include dependencies in the assembly

### DIFF
--- a/eu.neclab.iotplatform.iotbroker.builder/assembly.xml
+++ b/eu.neclab.iotplatform.iotbroker.builder/assembly.xml
@@ -10,19 +10,12 @@
 	<includeBaseDirectory>true</includeBaseDirectory>
     <baseDirectory></baseDirectory>
 
-	<dependencySets>
-	<dependencySet>
-			<outputDirectory>bundle</outputDirectory>
-		</dependencySet>
-	</dependencySets>
-
-
 	<moduleSets>
 		<moduleSet>
 			<useAllReactorProjects>false</useAllReactorProjects>
 			<includeSubModules>true</includeSubModules>
 			<binaries>
-				<includeDependencies>true</includeDependencies>
+				<includeDependencies>false</includeDependencies>
 				<outputDirectory>bundle</outputDirectory>
 				<unpack>false</unpack>
 			</binaries>


### PR DESCRIPTION
All (non Aeron) dependencies were being copied to the target folder
